### PR TITLE
Add `Agent::online` flag.

### DIFF
--- a/agent/src/agent.rs
+++ b/agent/src/agent.rs
@@ -126,7 +126,7 @@ impl Agent {
                         connection = self.reconnect(connection).await
                     }
                     Ok(None) => {
-                        log::warn!("control channel to server closed, reconnecting ...");
+                        log::warn!("control channel closed by server, reconnecting ...");
                         connection = self.reconnect(connection).await
                     }
                     Ok(Some(m)) => match self.on_message(&mut connection.writer, m).await {


### PR DESCRIPTION
Currently loosing either the control stream or the connection is
considered fatal and causes an immediate reconnect. This may
drop server messages. In order to process any outstanding messages,
we no longer reconnect immediately on connection loss but only
after the control stream has been drained. The new `online` flag
is used to prevent us from starting processes such as connection
tests since we know we can not report back the result.