### PR TITLE
CI Build Updates

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -12,221 +12,224 @@ jobs:
   check-release:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v4
+      - name: Checkout repository.
+        uses: actions/checkout@v4
 
-    - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+      - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
 
-    - name: Check if release exists.
-      shell: bash
-      run: |
-        gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-        ! gh release view "v${{ env.AGENT_VERSION }}" > /dev/null 2>&1
+      - name: Check if release exists.
+        shell: bash
+        run: |
+          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+          ! gh release view "v${{ env.AGENT_VERSION }}" > /dev/null 2>&1
 
-    - name: Check if changelog file exists.
-      shell: bash
-      run: test -f changelog/v${{ env.AGENT_VERSION }}.md
+      - name: Check if changelog file exists.
+        shell: bash
+        run: test -f changelog/v${{ env.AGENT_VERSION }}.md
 
   build-x86_64-linux:
     runs-on: ubuntu-latest
     needs:
       - check-release
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v4
+      - name: Checkout repository.
+        uses: actions/checkout@v4
 
-    - name: Install MUSL
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y musl-dev musl-tools
+      - name: Install cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
 
-    - name: Install MUSL target
-      run: rustup target add x86_64-unknown-linux-musl
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --version 2.0.5
 
-    - name: Install cargo-deb
-      run: cargo install cargo-deb --version 2.0.5
+      - name: Install cargo-generate-rpm
+        run: cargo install cargo-generate-rpm --version 0.14.0
 
-    - name: Install cargo-generate-rpm
-      run: cargo install cargo-generate-rpm --version 0.14.0
+      - name: Package agent (deb).
+        run: make deb-agent-x86_64
 
-    - name: Package agent (deb).
-      run: make deb-agent-x86_64
+      - name: Package agent (rpm).
+        run: make rpm-agent-x86_64
 
-    - name: Package agent (rpm).
-      run: make rpm-agent-x86_64
+      - name: Package agent (docker).
+        run: make docker-agent-x86_64-linux
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-    - name: Package agent (docker).
-      run: make docker-agent-x86_64-linux
-      env:
-        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
 
-    - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-linux.tar.xz
+          path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-linux.tar.xz"
+          retention-days: 1
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-linux.tar.xz
-        path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-linux.tar.xz"
-        retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent_${{ env.AGENT_VERSION }}_amd64.deb
+          path: "target/x86_64-unknown-linux-musl/debian/cluvio-agent_${{ env.AGENT_VERSION }}_amd64.deb"
+          retention-days: 1
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent_${{ env.AGENT_VERSION }}_amd64.deb
-        path: "target/x86_64-unknown-linux-musl/debian/cluvio-agent_${{ env.AGENT_VERSION }}_amd64.deb"
-        retention-days: 1
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-1.x86_64.rpm
-        path: "target/x86_64-unknown-linux-musl/generate-rpm/cluvio-agent-${{ env.AGENT_VERSION }}-1.x86_64.rpm"
-        retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-1.x86_64.rpm
+          path: "target/x86_64-unknown-linux-musl/generate-rpm/cluvio-agent-${{ env.AGENT_VERSION }}-1.x86_64.rpm"
+          retention-days: 1
 
   build-aarch64-linux:
     runs-on: ubuntu-latest
     needs:
       - check-release
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v4
+      - name: Checkout repository.
+        uses: actions/checkout@v4
 
-    - name: Install MUSL and other apt dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y musl-dev musl-tools gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu qemu-user-static binfmt-support
+      - name: Install cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
 
-    - name: Install MUSL target
-      run: rustup target add aarch64-unknown-linux-musl
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --version 2.0.5
 
-    - name: Install cargo-deb
-      run: cargo install cargo-deb --version 2.0.5
+      - name: Install cargo-generate-rpm
+        run: cargo install cargo-generate-rpm --version 0.14.0
 
-    - name: Install cargo-generate-rpm
-      run: cargo install cargo-generate-rpm --version 0.14.0
+      - name: Package agent (deb).
+        run: make deb-agent-aarch64
 
-    - name: Package agent (deb).
-      run: make deb-agent-aarch64
+      - name: Package agent (rpm).
+        run: make rpm-agent-aarch64
 
-    - name: Package agent (rpm).
-      run: make rpm-agent-aarch64
+      - name: Package agent (docker).
+        run: make docker-agent-aarch64-linux
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-    - name: Package agent (docker).
-      run: make docker-agent-aarch64-linux
-      env:
-        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
 
-    - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-linux.tar.xz
+          path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-linux.tar.xz"
+          retention-days: 1
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-linux.tar.xz
-        path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-linux.tar.xz"
-        retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent_${{ env.AGENT_VERSION }}_arm64.deb
+          path: "target/aarch64-unknown-linux-musl/debian/cluvio-agent_${{ env.AGENT_VERSION }}_arm64.deb"
+          retention-days: 1
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent_${{ env.AGENT_VERSION }}_arm64.deb
-        path: "target/aarch64-unknown-linux-musl/debian/cluvio-agent_${{ env.AGENT_VERSION }}_arm64.deb"
-        retention-days: 1
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-1.aarch64.rpm
-        path: "target/aarch64-unknown-linux-musl/generate-rpm/cluvio-agent-${{ env.AGENT_VERSION }}-1.aarch64.rpm"
-        retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-1.aarch64.rpm
+          path: "target/aarch64-unknown-linux-musl/generate-rpm/cluvio-agent-${{ env.AGENT_VERSION }}-1.aarch64.rpm"
+          retention-days: 1
 
   build-x86_64-macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - check-release
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v4
+      - name: Checkout repository.
+        uses: actions/checkout@v4
 
-    - name: Install Apple Darwin target
-      run: rustup target add x86_64-apple-darwin
+      - name: Install Apple Darwin target
+        run: rustup target add x86_64-apple-darwin
 
-    - name: Package agent.
-      run: make build-agent-x86_64-macos
-      env:
-        MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-        MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        MACOS_DEV_IDENTITY: ${{ secrets.MACOS_DEV_IDENTITY }}
-        APPLE_DEV_ACCOUNT: ${{ secrets.APPLE_DEV_ACCOUNT }}
-        APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - name: Package agent.
+        run: make build-agent-x86_64-macos
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_DEV_IDENTITY: ${{ secrets.MACOS_DEV_IDENTITY }}
+          APPLE_DEV_ACCOUNT: ${{ secrets.APPLE_DEV_ACCOUNT }}
+          APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-    - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+      - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.tar.xz
-        path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.tar.xz"
-        retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.tar.xz
+          path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.tar.xz"
+          retention-days: 1
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.dmg
-        path: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.dmg
-        retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.dmg
+          path: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.dmg
+          retention-days: 1
 
   build-aarch64-macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - check-release
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v4
+      - name: Checkout repository.
+        uses: actions/checkout@v4
 
-    - name: Install Apple Darwin target
-      run: rustup target add aarch64-apple-darwin
+      - name: Install Apple Darwin target
+        run: rustup target add aarch64-apple-darwin
 
-    - name: Package agent.
-      run: make build-agent-aarch64-macos
-      env:
-        MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-        MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        MACOS_DEV_IDENTITY: ${{ secrets.MACOS_DEV_IDENTITY }}
-        APPLE_DEV_ACCOUNT: ${{ secrets.APPLE_DEV_ACCOUNT }}
-        APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - name: Select SDK Version
+        run: sudo xcode-select -s "/Applications/Xcode_14.0.1.app" # macosx12.3
 
-    - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+      - name: Show SDK Version
+        run: xcrun --show-sdk-platform-version # macosx12.3 = MACOSX_DEPLOYMENT_TARGET
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.tar.xz
-        path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.tar.xz"
-        retention-days: 1
+      - name: Package agent.
+        run: make build-agent-aarch64-macos
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_DEV_IDENTITY: ${{ secrets.MACOS_DEV_IDENTITY }}
+          APPLE_DEV_ACCOUNT: ${{ secrets.APPLE_DEV_ACCOUNT }}
+          APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.dmg
-        path: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.dmg
-        retention-days: 1
+      - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.tar.xz
+          path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.tar.xz"
+          retention-days: 1
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.dmg
+          path: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.dmg
+          retention-days: 1
 
   build-x86_64-windows:
     runs-on: windows-latest
     needs:
       - check-release
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v4
+      - name: Checkout repository.
+        uses: actions/checkout@v4
 
-    - name: Install Windows target
-      run: rustup target add x86_64-pc-windows-msvc
+      - name: Install NASM
+        run: |
+          choco install nasm
+          echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Package agent.
-      run: make build-agent-x86_64-windows
+      - name: Install Windows target
+        run: rustup target add x86_64-pc-windows-msvc
 
-    - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
-      shell: bash
+      - name: Package agent.
+        run: make build-agent-x86_64-windows
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-windows.zip
-        path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-windows.zip"
-        retention-days: 1
+      - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+        shell: bash
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-windows.zip
+          path: "dist/cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-windows.zip"
+          retention-days: 1
 
   release:
     runs-on: ubuntu-latest
@@ -237,75 +240,75 @@ jobs:
       - build-aarch64-macos
       - build-x86_64-windows
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v4
+      - name: Checkout repository.
+        uses: actions/checkout@v4
 
-    - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
+      - run: echo AGENT_VERSION=$(make agent-version) >> $GITHUB_ENV
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-linux.tar.xz
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-linux.tar.xz
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.tar.xz
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.tar.xz
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.dmg
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-aarch64-macos.dmg
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-linux.tar.xz
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-linux.tar.xz
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.tar.xz
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.tar.xz
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.dmg
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-macos.dmg
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-windows.zip
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-x86_64-windows.zip
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent_${{ env.AGENT_VERSION }}_amd64.deb
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent_${{ env.AGENT_VERSION }}_amd64.deb
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent_${{ env.AGENT_VERSION }}_arm64.deb
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent_${{ env.AGENT_VERSION }}_arm64.deb
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-1.x86_64.rpm
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-1.x86_64.rpm
+          path: dist/
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: cluvio-agent-${{ env.AGENT_VERSION }}-1.aarch64.rpm
-        path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: cluvio-agent-${{ env.AGENT_VERSION }}-1.aarch64.rpm
+          path: dist/
 
-    - name: Create release.
-      shell: bash
-      run: |
-        (cd dist && sha256sum *.* > CHECKSUMS)
-        gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-        gh release create -d -t "v${{ env.AGENT_VERSION }}" -F changelog/v${{ env.AGENT_VERSION }}.md "v${{ env.AGENT_VERSION }}" dist/*
+      - name: Create release.
+        shell: bash
+        run: |
+          (cd dist && sha256sum *.* > CHECKSUMS)
+          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+          gh release create -d -t "v${{ env.AGENT_VERSION }}" -F changelog/v${{ env.AGENT_VERSION }}.md "v${{ env.AGENT_VERSION }}" dist/*
 
-    - name: Release on docker hub.
-      run: make docker-agent-release
-      env:
-        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Release on docker hub.
+        run: make docker-agent-release
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca2be1d5c43812bae364ee3f30b3afcb7877cf59f4aeb94c66f313a41d2fac9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
 ]
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64",
  "rustls-pki-types",
@@ -1365,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
  "memchr",
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.6"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = ["agent", "protocol", "sealed-boxes", "util"]
 [profile.release]
 codegen-units = 1
 lto = true
+strip = true

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -21,7 +21,7 @@ sealed-boxes = { path = "../sealed-boxes" }
 serde        = { version = "1.0.196", features = ["derive"] }
 socket2      = { version = "0.5.4", features = ["all"] }
 thiserror    = "1.0.50"
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "aws-lc-rs"] }
 tokio-util   = { version = "0.7.10", features = ["compat"] }
 util         = { path = "../util" }
 webpki-roots = "0.26"

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -3,15 +3,12 @@ use cluvio_agent::{self, Agent, Config, Options};
 use directories::BaseDirs;
 use std::env;
 use std::path::{Path, PathBuf};
-use tokio_rustls::rustls::crypto::aws_lc_rs;
 use util::{base64, exit};
 
 const CONFIG_FILE_NAME: &str = "cluvio-agent.toml";
 
 #[tokio::main]
 async fn main() {
-    aws_lc_rs::default_provider().install_default().expect("aws-lc not available");
-
     let opts = Options::parse();
 
     if opts.version {

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -15,7 +15,7 @@ rand_core      = "0.6.4"
 rustls-pemfile = "2.1.2"
 sealed-boxes   = { path = "../sealed-boxes" }
 serde          = { version = "1.0.196", features = ["derive"] }
-tokio-rustls   = "0.26"
+tokio-rustls   = { version = "0.26", default-features = false }
 
 [dependencies.chacha20poly1305]
 version = "0.10"


### PR DESCRIPTION
Use cross-rs/cross for compiling linux musl targets. This avoids linking issues of the previous build setup after switching to the latest rustls and the new default aws-lc-rs crypto provider.

The windows build is updated to install NASM required for the compilation of aws-lc-rs on the x86_64-pc-windows-msvc target.

The MacOS build is updated to now build on and for >= MacOS 12 as MacOS 11 is longer supported both by Apple and Github CI.

Stripping of binaries is now left to cargo/rustc.